### PR TITLE
refactoring of bazelrc

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,1 +1,1 @@
-build:default --copt="-std=c++17" --copt="-fconcepts" --copt="-Werror" --copt="-O3"
+build --copt="-std=c++17" --copt="-Werror" --copt="-O3"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,38 +39,38 @@ jobs:
 
       - name: Build rel_lib
         run: |
-          "${GITHUB_WORKSPACE}/bin/bazel" build --config=default //rel-lib:rel_lib
+          "${GITHUB_WORKSPACE}/bin/bazel" build //rel-lib:rel_lib
       
       - name: Build rel_cli
         run: |
-          "${GITHUB_WORKSPACE}/bin/bazel" build --config=default //rel-cli:rel_cli
+          "${GITHUB_WORKSPACE}/bin/bazel" build //rel-cli:rel_cli
 
       - name: Build rel_ls
         run: |
-          "${GITHUB_WORKSPACE}/bin/bazel" build --config=default //rel-ls:rel_ls
+          "${GITHUB_WORKSPACE}/bin/bazel" build //rel-ls:rel_ls
 
       - name: Build rel_py
         run: |
-          "${GITHUB_WORKSPACE}/bin/bazel" build --config=default //relpy:rel_py
+          "${GITHUB_WORKSPACE}/bin/bazel" build //relpy:rel_py
 
 
       # Run unittests
       - name: Run rel_lib Unittest
         run: |
-          "${GITHUB_WORKSPACE}/bin/bazel" test --config=default //rel-lib/test/unittest:RelLibUnitTest
+          "${GITHUB_WORKSPACE}/bin/bazel" test //rel-lib/test/unittest:RelLibUnitTest
 
       - name: Run rel_ls Unittest
         run: |
-          "${GITHUB_WORKSPACE}/bin/bazel" test --config=default //rel-ls/test/unittest:RelLsUnitTest
+          "${GITHUB_WORKSPACE}/bin/bazel" test //rel-ls/test/unittest:RelLsUnitTest
 
       - name: Run rel_cli Unittest
         run: |
-          "${GITHUB_WORKSPACE}/bin/bazel" test --config=default //rel-cli/test/unittest:RelCliUnitTest
+          "${GITHUB_WORKSPACE}/bin/bazel" test //rel-cli/test/unittest:RelCliUnitTest
 
       # Run integration tests
       - name: Integration Test Python Integration
         run: |
-          "${GITHUB_WORKSPACE}/bin/bazel" test --config=default //relpy/test:integration_test
+          "${GITHUB_WORKSPACE}/bin/bazel" test //relpy/test:integration_test
 
       # Process models
       - name: Validate REL requirements

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ The following tools are required to build and run REL:
 To process [REL framework requirements](./requirements), execute the following steps:
 
 1. Clone this repository from Github
-1. Build [REL command line interface](./rel-cli): `bazel build --config=default //rel-cli:rel_cli`
+1. Build [REL command line interface](./rel-cli): `bazel build //rel-cli:rel_cli`
 1. Run the binary with the following command: `bazel-bin/rel-cli/rel_cli -r -v ./requirements/`
 
 # Further Documentation

--- a/rel-cli/README.md
+++ b/rel-cli/README.md
@@ -16,14 +16,14 @@ rel_cli [-r] [-v|-vv] <PATH>
 # How to build rel_cli
 
 ```
-bazel build --config=default  //rel-cli:rel_cli
+bazel build //rel-cli:rel_cli
 ``` 
 
 # Test Environment
 
 Run unittests:
 ```
-bazel test --config=default //rel-cli/test/unittest:RelCliUnitTest
+bazel test //rel-cli/test/unittest:RelCliUnitTest
 ``` 
 
 Process test data set:

--- a/rel-lib/README.md
+++ b/rel-lib/README.md
@@ -5,7 +5,7 @@ C++ library, that implements REL and is used in different contexts, e.g. for the
 # How to Build rel_lib
 
 ```
-bazel build --config=default  //rel-lib:rel_lib
+bazel build //rel-lib:rel_lib
 ``` 
 
 # Test Environment
@@ -13,7 +13,7 @@ bazel build --config=default  //rel-lib:rel_lib
 Unit Tests:
 
 ```
-bazel test --config=default //rel-lib/test/unittest:RelLibUnitTest
+bazel test //rel-lib/test/unittest:RelLibUnitTest
 ```
 
 # Software Architecture

--- a/rel-lib/src/FileEngine.cpp
+++ b/rel-lib/src/FileEngine.cpp
@@ -28,7 +28,8 @@ void FileEngine::SetStartDirectory(std::string const sd) {
     start_directory = sd;
 }
 
-void FileEngine::CreateFileTokenData(auto const &entry, std::map<std::string, DataType> &filetype_identifier,
+template<typename T>
+void FileEngine::CreateFileTokenData(T const &entry, std::map<std::string, DataType> &filetype_identifier,
                                      std::set<FileTokenData, decltype(ftd_cmp)*> &files_sorted) const {
     if (entry.is_regular_file()) {
         std::string ext = entry.path().extension();

--- a/rel-lib/src/FileEngine.h
+++ b/rel-lib/src/FileEngine.h
@@ -30,7 +30,8 @@ public:
     bool GetSearchRecursive() const;
 
 protected:
-    void CreateFileTokenData(auto const&, std::map<std::string, DataType>&,
+   template<typename T>
+    void CreateFileTokenData(T const&, std::map<std::string, DataType>&,
                              std::set<FileTokenData, decltype(ftd_cmp)*>&) const;
 
     bool search_recursive;

--- a/rel-ls/README.md
+++ b/rel-ls/README.md
@@ -21,7 +21,7 @@ Currently supported version of LSP: [3.15](https://microsoft.github.io/language-
 Build language server binary with the following bazel command:
 
 ```
-bazel build --config=default  //rel-ls:rel_ls
+bazel build //rel-ls:rel_ls
 ``` 
 
 # Test Environment
@@ -29,5 +29,5 @@ bazel build --config=default  //rel-ls:rel_ls
 Unit Tests:
 
 ```
-bazel test --config=default //rel-ls/test/unittest:RelLsUnitTest
+bazel test //rel-ls/test/unittest:RelLsUnitTest
 ``` 

--- a/relpy/README.md
+++ b/relpy/README.md
@@ -8,12 +8,12 @@ Python3 integration of REL is using [pybind11](https://github.com/pybind/pybind1
 
 # How to build Python3 module for REL
 ```
-bazel build --config=default  //relpy:rel_py
+bazel build //relpy:rel_py
 ``` 
 
 # Run integration test of rel_py
 ```
-bazel test --config=default //relpy/test:integration_test
+bazel test //relpy/test:integration_test
 ```
 
 


### PR DESCRIPTION
removed unnecessary compiler option
and made all options default for build
command, without the need for own
configuration