### PR TITLE
bazel rules to run rel_cli

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -86,12 +86,12 @@ jobs:
       # Process models
       - name: Validate REL Requirements on Command Line
         run: |
-          "${GITHUB_WORKSPACE}/bazel-bin/rel-cli/rel_cli" -r -v ./requirements
+          "${GITHUB_WORKSPACE}/bin/bazel" run //requirements:validate_rel_requirements
 
       - name: Validate Big Test Project on Command Line
         run: |
-          "${GITHUB_WORKSPACE}/bazel-bin/rel-cli/rel_cli" -r -v ./test/big
+          "${GITHUB_WORKSPACE}/bin/bazel" run //test:validate_big_testmodel
           
       - name: Validate Huge Test Project on Command Line
         run: |
-          "${GITHUB_WORKSPACE}/bazel-bin/rel-cli/rel_cli" -r -v ./test/huge
+          "${GITHUB_WORKSPACE}/bin/bazel" run //test:validate_huge_testmodel

--- a/rel-cli/BUILD
+++ b/rel-cli/BUILD
@@ -6,4 +6,11 @@ cc_binary(
     deps = [
             "//rel-cli/src:rel_cli_lib",
     ],
+    visibility = ["//visibility:public"],
+)
+
+filegroup(
+    name = "rel_cli_script",
+    srcs = ["rel_cli.sh"],
+    visibility = ["//visibility:public"],
 )

--- a/rel-cli/rel_cli.sh
+++ b/rel-cli/rel_cli.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+./rel-cli/rel_cli "$@"

--- a/requirements/BUILD
+++ b/requirements/BUILD
@@ -1,0 +1,13 @@
+filegroup(
+    name = "rel_requirements",
+    srcs = glob(["*.rd"]) + ["spec.rs"],
+    visibility = ["//visibility:public"],
+)
+
+sh_binary(
+    name = "validate_rel_requirements",
+    srcs = ["//rel-cli:rel_cli_script"],
+    args = ["-r", "-v", "./requirements"],
+    data = [":rel_requirements", "//rel-cli:rel_cli"],
+    visibility = ["//visibility:public"],
+)

--- a/test/BUILD
+++ b/test/BUILD
@@ -6,6 +6,13 @@ filegroup(
         ],
     visibility = ["//visibility:public"],
 )
+sh_binary(
+    name = "validate_small_testmodel",
+    srcs = ["//rel-cli:rel_cli_script"],
+    args = ["-r", "-v", "./test/small"],
+    data = [":small_test_model", "//rel-cli:rel_cli"],
+    visibility = ["//visibility:public"],
+)
 
 filegroup(
     name = "invalid_test_model",
@@ -21,9 +28,23 @@ filegroup(
     srcs = glob(["big/**/*.rd"]) + ["big/spec.rs"],
     visibility = ["//visibility:public"],
 )
+sh_binary(
+    name = "validate_big_testmodel",
+    srcs = ["//rel-cli:rel_cli_script"],
+    args = ["-r", "-v", "./test/big"],
+    data = [":big_test_model", "//rel-cli:rel_cli"],
+    visibility = ["//visibility:public"],
+)
 
 filegroup(
     name = "huge_test_model",
     srcs = glob(["huge/**/*.rd"]) + ["huge/spec.rs"],
+    visibility = ["//visibility:public"],
+)
+sh_binary(
+    name = "validate_huge_testmodel",
+    srcs = ["//rel-cli:rel_cli_script"],
+    args = ["-r", "-v", "./test/huge"],
+    data = [":huge_test_model", "//rel-cli:rel_cli"],
     visibility = ["//visibility:public"],
 )


### PR DESCRIPTION
added bazel rules, to run rel_cli
on command line via bazel