### PR TITLE
Identifier can now contain dot

### DIFF
--- a/rel-lib/grammar/grammar.g
+++ b/rel-lib/grammar/grammar.g
@@ -31,7 +31,7 @@ enum_definition ::= ENUM identifier {
     [identifier,]+
 }
 
-identifier ::= [a-zA-Z_][a-zA-Z0-9_]*
+identifier ::= [a-zA-Z_\.][a-zA-Z0-9_\.]*
 
 
 
@@ -69,4 +69,4 @@ enum_element ::= identifier
 
 string ::= QUOTATION_MARK [QUOTATION_MARK_MASKED | .]* QUOTATION_MARK
 
-identifier ::= [a-zA-Z_][a-zA-Z0-9_]*
+identifier ::= [a-zA-Z_\.][a-zA-Z0-9_\.]*

--- a/rel-lib/src/Lexer.cpp
+++ b/rel-lib/src/Lexer.cpp
@@ -95,12 +95,12 @@ bool Lexer::IsInteger(std::string const &s) {
 
 bool Lexer::IsIdentifier(std::string const &s) {
     unsigned char first_character = s[0];
-    if( !(std::isalpha(first_character) != 0 || first_character == '_') )
+    if( !(std::isalpha(first_character) != 0 || first_character == '_' || first_character == '.') )
         return false;
 
     return std::find_if(s.begin()+1, s.end(),
                         [](unsigned char c) {
-                            return (!std::isalnum(c) && !(c == '_')) ;
+                            return (!std::isalnum(c) && !(c == '_') && !(c == '.'));
                         }) == s.end();
 }
 

--- a/rel-lib/test/unittest/FileEngineTest.cpp
+++ b/rel-lib/test/unittest/FileEngineTest.cpp
@@ -48,7 +48,7 @@ TEST_F(FileEngineFixture, SearchFileNonRecursive2) {
 
     std::vector<FileTokenData> res = GetListOfFiles();
 
-    EXPECT_EQ(res.size(), 2);
+    EXPECT_EQ(res.size(), 3);
 }
 
 TEST_F(FileEngineFixture, SearchFileRecursive1) {
@@ -57,7 +57,7 @@ TEST_F(FileEngineFixture, SearchFileRecursive1) {
 
     std::vector<FileTokenData> res = GetListOfFiles();
 
-    EXPECT_EQ(res.size(), 7);
+    EXPECT_EQ(res.size(), 9);
 }
 
 TEST_F(FileEngineFixture, NoDirectorySpecified) {
@@ -73,7 +73,7 @@ TEST_F(FileEngineFixture, SearchMultipleDirs) {
 
     std::vector<FileTokenData> res = GetListOfFiles();
 
-    EXPECT_EQ(res.size(), 4);
+    EXPECT_EQ(res.size(), 5);
 }
 
 TEST_F(FileEngineFixture, SearchMultipleDirsRecursively) {
@@ -83,5 +83,5 @@ TEST_F(FileEngineFixture, SearchMultipleDirsRecursively) {
 
     std::vector<FileTokenData> res = GetListOfFiles();
 
-    EXPECT_EQ(res.size(), 9);
+    EXPECT_EQ(res.size(), 11);
 }

--- a/rel-lib/test/unittest/LexerTest.cpp
+++ b/rel-lib/test/unittest/LexerTest.cpp
@@ -9,7 +9,7 @@ protected:
 
   void SetUp() override {
       token_list = new std::list<Token>();
-      logger.SetLogLevel(LogLevel::DBUG);
+      //logger.SetLogLevel(LogLevel::DBUG);
   }
 
   void TearDown() override {
@@ -265,6 +265,16 @@ TEST_F(LexerTestFixture, IsIdentifier)
     EXPECT_TRUE ( IsIdentifier("a") );
     EXPECT_TRUE ( IsIdentifier("X") );
     EXPECT_TRUE ( IsIdentifier("_") );
+    EXPECT_TRUE ( IsIdentifier("ab.cd") );
+    EXPECT_TRUE ( IsIdentifier("XHDHD.") );
+    EXPECT_TRUE ( IsIdentifier("XH.DHD") );
+    EXPECT_TRUE ( IsIdentifier("a.b.c.d.") );
+    EXPECT_TRUE ( IsIdentifier("a.b.c.d.erere") );
+    EXPECT_TRUE ( IsIdentifier(".b.c.d.erere") );
+    EXPECT_TRUE ( IsIdentifier(".") );
+    EXPECT_TRUE ( IsIdentifier(".fsa") );
+    EXPECT_TRUE ( IsIdentifier("......___....") );
+    EXPECT_TRUE ( IsIdentifier(".....") );
 
     EXPECT_FALSE ( IsIdentifier("20_30") );
     EXPECT_FALSE ( IsIdentifier("1") );
@@ -274,6 +284,7 @@ TEST_F(LexerTestFixture, IsIdentifier)
     EXPECT_FALSE ( IsIdentifier("-1273t67") );
     EXPECT_FALSE ( IsIdentifier("1237") );
     EXPECT_FALSE ( IsIdentifier(" ") );
+    EXPECT_FALSE ( IsIdentifier("-----") );
 }
 
 TEST_F(LexerTestFixture, IsString)

--- a/rel-lib/test/unittest/RdParserTest.cpp
+++ b/rel-lib/test/unittest/RdParserTest.cpp
@@ -201,6 +201,27 @@ TEST_F(RdParserTestFixture, SingleDataset2) {
     EXPECT_EQ(database.front().type_instances[0].attributes.size(), 4);
 }
 
+TEST_F(RdParserTestFixture, DatasetWithNamespace) {
+    spec = "type System.OS { Identifier : id, Number : int, Text : string, Parent : link,}";
+    data = "System.OS { Identifier : OS.r1, Number : 1234, Text : \"1234\", Parent : OS.r1,}";
+
+    FileReader r_spec(spec);
+    FileTokenData d_spec(DataType::RequirementsSpecification, r_spec);
+
+    FileReader r_data(data);
+    FileTokenData d_data(DataType::RequirementsData, r_data);
+
+    lexer_test.Read(d_spec);
+    lexer_test.Read(d_data);
+    rs_parser.ParseTokens(d_spec);
+
+    ParseTokens(d_data);
+
+    EXPECT_EQ(database.size(), 1);
+    EXPECT_EQ(database.front().type_instances.size(), 1);
+    EXPECT_EQ(database.front().type_instances[0].attributes.size(), 4);
+}
+
 TEST_F(RdParserTestFixture, DatasetWithMaskedQuotationMark) {
     spec = "type Req { Text : string, }";
     data = "Req { Text : \"I would like to \\\"emphasize\\\" this part and mo\\\"re\",}";
@@ -238,6 +259,33 @@ TEST_F(RdParserTestFixture, DatasetWithEnum) {
 
     RdParser rd_parser(logger, rs_parser);
     rd_parser.ParseTokens(d_data);
+
+    EXPECT_EQ(rd_parser.GetDatabase().size(), 1);
+    EXPECT_EQ(rd_parser.GetDatabase().front().type_instances.size(), 1);
+    EXPECT_EQ(rd_parser.GetDatabase().front().type_instances[0].attributes.size(), 1);
+}
+
+TEST_F(RdParserTestFixture, DatasetWithNamespaceEnum) {
+    spec = "type Req { Color : OS.Color,} enum OS.Color {Clr.red, Clr.blue,}";
+    data = "Req { Color : Clr.red,}";
+
+    FileReader r_spec(spec);
+    FileTokenData d_spec(DataType::RequirementsSpecification, r_spec);
+
+    FileReader r_data(data);
+    FileTokenData d_data(DataType::RequirementsData, r_data);
+
+    lexer_test.Read(d_spec);
+    lexer_test.Read(d_data);
+    rs_parser.ParseTokens(d_spec);
+    rs_parser.CheckAllEnumTypes();
+
+    RdParser rd_parser(logger, rs_parser);
+    rd_parser.ParseTokens(d_data);
+
+    EXPECT_EQ(rd_parser.GetDatabase().size(), 1);
+    EXPECT_EQ(rd_parser.GetDatabase().front().type_instances.size(), 1);
+    EXPECT_EQ(rd_parser.GetDatabase().front().type_instances[0].attributes.size(), 1);
 }
 
 TEST_F(RdParserTestFixture, ParseErrorWrongToken) {

--- a/rel-lib/test/unittest/RsParserTest.cpp
+++ b/rel-lib/test/unittest/RsParserTest.cpp
@@ -63,6 +63,20 @@ TEST_F(RsParserTestFixture, TypeDefinition) {
     EXPECT_EQ(all_types["XXX"].attributes.size(), 4);
 }
 
+TEST_F(RsParserTestFixture, TypeDefinitionWithNamespace) {
+    testdata = "type System.OS { attribute : id, attribtue2 : link, attr3 : string, attr4 : int,}";
+
+    FileReader r(testdata);
+    FileTokenData d(DataType::RequirementsSpecification, r);
+
+    lexer_test.Read(d);
+    ParseTokens(d);
+
+    EXPECT_EQ(all_enums.size(), 0);
+    EXPECT_EQ(all_types.size(), 1);
+    EXPECT_EQ(all_types["System.OS"].attributes.size(), 4);
+}
+
 TEST_F(RsParserTestFixture, WrongToken) {
     testdata = ",type XXX { attribute  id, attribtue2 : link, attr3 : string, attr4 : int,}";
 

--- a/relpy/test/integration_test_big.py
+++ b/relpy/test/integration_test_big.py
@@ -21,7 +21,7 @@ def test_big_project():
     for files in data:
         nr_of_type_instances = nr_of_type_instances + len(files.type_instances)
 
-    assert nr_of_type_instances == 4041
+    assert nr_of_type_instances == 4043
 
     # check that the data has been parsed properly
     for files in data:

--- a/relpy/test/integration_test_small_big.py
+++ b/relpy/test/integration_test_small_big.py
@@ -22,7 +22,7 @@ def test_small_and_big_project():
     for files in data:
         type_inst = type_inst + len(files.type_instances)
 
-    assert type_inst == 4045
+    assert type_inst == 4047
 
 # main
 test_small_and_big_project()

--- a/test/BUILD
+++ b/test/BUILD
@@ -25,7 +25,7 @@ filegroup(
 
 filegroup(
     name = "big_test_model",
-    srcs = glob(["big/**/*.rd"]) + ["big/spec.rs"],
+    srcs = glob(["big/**/*.rd"]) + ["big/spec.rs"] + ["big/spec_camera.rs"],
     visibility = ["//visibility:public"],
 )
 sh_binary(

--- a/test/big/SystemRequirements/Hardware/camera.rd
+++ b/test/big/SystemRequirements/Hardware/camera.rd
@@ -1,0 +1,13 @@
+Camera.Requirement
+{
+    Identifier : camera.123,
+    Text : "requirement text",
+    Supplier : CompanyB,
+}
+
+Camera.Requirement
+{
+    Identifier : camera.a2,
+    Text : "requirement text",
+    Supplier : CompanyA,
+}

--- a/test/big/spec_camera.rs
+++ b/test/big/spec_camera.rs
@@ -1,0 +1,18 @@
+type Camera.Requirement
+{
+    // unique identifier
+    Identifier : id,
+    // Description of the requirement
+    Text : string,
+    Supplier : Camera.Supplier,
+}
+
+
+
+// #### Enum Definitions
+enum Camera.Supplier
+{
+    CompanyA,
+    CompanyB,
+    CompanyC,
+}


### PR DESCRIPTION
An identifier can now contain the
dot character, so that it is possible
to define a namespace, for subsequent
processing in other tools.